### PR TITLE
Paramaterise output path and allow other environment inputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 ARG ALPINE_VERSION=3.18
 ARG IAMLIVE_VERSION=v0.53.0
+ARG FORMAT_LOGS='true'
+ARG ALLOWED_ADDRESS='0.0.0.0'
+ARG OUTPUT_PATH='/app/iamlive.log'
 
-
-# Base image
+# Environment
 FROM alpine:${ALPINE_VERSION} AS base
 RUN apk --update upgrade && \
     apk add --update ca-certificates bash jq=~1.6 && \
     update-ca-certificates
-
 
 # Download iamlive binary from GitHub
 FROM base as download
@@ -17,9 +18,14 @@ RUN \
     wget -O iamlive.tar.gz "https://github.com/iann0036/iamlive/releases/download/${IAMLIVE_VERSION}/iamlive-${IAMLIVE_VERSION}-linux-amd64.tar.gz" && \
     tar -xzf iamlive.tar.gz
 
-
 # App
 FROM base AS app
+ARG FORMAT_LOGS
+ARG ALLOWED_ADDRESS
+ARG OUTPUT_PATH
+ENV FORMAT_LOGS=$FORMAT_LOGS
+ENV ALLOWED_ADDRESS=$ALLOWED_ADDRESS
+ENV OUTPUT_PATH=$OUTPUT_PATH
 WORKDIR /app/
 COPY --from=download "/downloads/iamlive" ./
 RUN addgroup -S "appgroup" && adduser -S "appuser" -G "appgroup" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 _FORMAT_LOGS="${FORMAT_LOGS:-"true"}"
 _ALLOWED_ADDRESS="${ALLOWED_ADDRESS:-"0.0.0.0"}"
-_OUTPUT_PATH="${_OUTPUT_PATH:-"/app/iamlive.log"}"
+_OUTPUT_PATH="${OUTPUT_PATH:-"/app/iamlive.log"}"
 
 if [[ "$_FORMAT_LOGS" = "true" ]]; then
     /app/iamlive --output-file "${_OUTPUT_PATH}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,11 +5,12 @@ set -o pipefail
 
 _FORMAT_LOGS="${FORMAT_LOGS:-"true"}"
 _ALLOWED_ADDRESS="${ALLOWED_ADDRESS:-"0.0.0.0"}"
+_OUTPUT_PATH="${_OUTPUT_PATH:-"/app/iamlive.log"}"
 
 if [[ "$_FORMAT_LOGS" = "true" ]]; then
-    /app/iamlive --output-file "/app/iamlive.log" \
+    /app/iamlive --output-file "${_OUTPUT_PATH}" \
         --mode proxy --bind-addr "${_ALLOWED_ADDRESS}:10080" $@ | jq -c .
 else
-    /app/iamlive --output-file "/app/iamlive.log" \
+    /app/iamlive --output-file "${_OUTPUT_PATH}" \
         --mode proxy --bind-addr "${_ALLOWED_ADDRESS}:10080" $@
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,9 @@
 set -e
 set -o pipefail
 
-_FORMAT_LOGS="${FORMAT_LOGS:-"true"}"
-_ALLOWED_ADDRESS="${ALLOWED_ADDRESS:-"0.0.0.0"}"
-_OUTPUT_PATH="${OUTPUT_PATH:-"/app/iamlive.log"}"
+_FORMAT_LOGS="${FORMAT_LOGS}"
+_ALLOWED_ADDRESS="${ALLOWED_ADDRESS}"
+_OUTPUT_PATH="${OUTPUT_PATH}"
 
 if [[ "$_FORMAT_LOGS" = "true" ]]; then
     /app/iamlive --output-file "${_OUTPUT_PATH}" \


### PR DESCRIPTION
Proposed changes:

- Adds paramaterises input for an output path as `OUTPUT_PATH` (will be useful when working in CI and stuck with certain relative paths)
- Moves the new `OUTPUT_PATH`, `ALLOWED_ADDRESS` and `FORMAT_LOGS` variables to the Dockerfile rather than entrypoint script that they might be easier managed and modified at either build time or clobbered at run time